### PR TITLE
Watchgroups

### DIFF
--- a/demo.jinja
+++ b/demo.jinja
@@ -13,4 +13,18 @@ target_link_libraries(
     pthread
     )
 
+add_executable(
+    demo_watchgroups
+    {% for s in source + target.demo_watchgroups -%}
+    {{ s }}
+    {% endfor %}
+    )
+
+target_link_libraries(
+    demo
+    pthread
+    )
+
+
+
 {% endblock %}

--- a/examples/posix/demo_watchgroups.c
+++ b/examples/posix/demo_watchgroups.c
@@ -35,16 +35,21 @@ static void *observer(void *p)
     condvar_wrapper_t wrapper = {PTHREAD_MUTEX_INITIALIZER,
                                  PTHREAD_COND_INITIALIZER};
 
+    messagebus_watcher_t watchers[2];
     messagebus_watchgroup_init(&group, &wrapper, &wrapper);
-    messagebus_watchgroup_watch(&group,
+    messagebus_watchgroup_watch(&watchers[0],
+                                &group,
                                 messagebus_find_topic_blocking(&bus, "foo"));
-    messagebus_watchgroup_watch(&group,
+    messagebus_watchgroup_watch(&watchers[1],
+                                &group,
                                 messagebus_find_topic_blocking(&bus, "bar"));
 
     while (1) {
         messagebus_topic_t *topic;
         topic = messagebus_watchgroup_wait(&group);
-        printf("[observer] Received on \"%s\"\n", topic->name);
+        printf("[observer] Received a message of size %ld on \"%s\"\n",
+               topic->buffer_len,
+               topic->name);
     }
 }
 

--- a/examples/posix/demo_watchgroups.c
+++ b/examples/posix/demo_watchgroups.c
@@ -1,0 +1,89 @@
+#include <unistd.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include "../../messagebus.h"
+#include "port.h"
+
+messagebus_t bus;
+
+static void* producer(void *p)
+{
+    messagebus_topic_t *topic;
+    int counter = 0;
+
+    char *topic_name = (char *)p;
+
+    printf("[publisher] waiting for topic \"%s\"\n", topic_name);
+
+    while (1) {
+        topic = messagebus_find_topic_blocking(&bus, topic_name);
+        printf("[publisher] writing %d on topic %s\n", counter, topic->name);
+        messagebus_topic_publish(topic, &counter, sizeof counter);
+        counter += 1;
+        sleep(2);
+    }
+
+    return NULL;
+}
+
+static void *observer(void *p)
+{
+    messagebus_watchgroup_t group;
+
+    condvar_wrapper_t wrapper = {PTHREAD_MUTEX_INITIALIZER,
+                                 PTHREAD_COND_INITIALIZER};
+
+    messagebus_watchgroup_init(&group, &wrapper, &wrapper);
+    messagebus_watchgroup_watch(&group,
+                                messagebus_find_topic_blocking(&bus, "foo"));
+    messagebus_watchgroup_watch(&group,
+                                messagebus_find_topic_blocking(&bus, "bar"));
+
+    while (1) {
+        messagebus_topic_t *topic;
+        topic = messagebus_watchgroup_wait(&group);
+        printf("[observer] Received on \"%s\"\n", topic->name);
+    }
+}
+
+static void create_topic(const char *name)
+{
+    messagebus_topic_t *topic = malloc(sizeof(messagebus_topic_t));
+    int *buffer = malloc(sizeof(int));
+    condvar_wrapper_t *sync = malloc(sizeof(condvar_wrapper_t));
+    pthread_mutex_init(&sync->mutex, NULL);
+    pthread_cond_init(&sync->cond, NULL);
+
+    messagebus_topic_init(topic, sync, sync, buffer, sizeof(int));
+    messagebus_advertise_topic(&bus, topic, name);
+}
+
+int main(int argc, const char **argv)
+{
+    (void) argc;
+    (void) argv;
+
+    /* Create the message bus. */
+    condvar_wrapper_t bus_sync = {PTHREAD_MUTEX_INITIALIZER,
+                                  PTHREAD_COND_INITIALIZER};
+    messagebus_init(&bus, &bus_sync, &bus_sync);
+
+    /* Creates a topic and publish it on the bus. */
+    create_topic("foo");
+    create_topic("bar");
+
+    /* Create publishers */
+    pthread_t producer_foo_thd, producer_bar_thd;
+    pthread_create(&producer_foo_thd, NULL, producer, "foo");
+    sleep(1);
+    pthread_create(&producer_bar_thd, NULL, producer, "bar");
+
+    /* Observer thread */
+    pthread_t observer_thd;
+    pthread_create(&observer_thd, NULL, observer, NULL);
+
+    while (1) {
+    }
+}

--- a/messagebus.h
+++ b/messagebus.h
@@ -17,6 +17,7 @@ typedef struct topic_s {
     char name[TOPIC_NAME_MAX_LENGTH + 1];
     struct topic_s *next;
     bool published;
+    struct messagebus_watchgroup_s *groups;
 } messagebus_topic_t;
 
 typedef struct {
@@ -26,6 +27,13 @@ typedef struct {
     void *lock;
     void *condvar;
 } messagebus_t;
+
+typedef struct messagebus_watchgroup_s {
+    void *lock;
+    void *condvar;
+    struct messagebus_watchgroup_s *next;
+    messagebus_topic_t *published_topic;
+} messagebus_watchgroup_t;
 
 #define MESSAGEBUS_TOPIC_FOREACH(_bus, _topic_var_name) \
     for (int __control = -1; __control < 2; __control++) \
@@ -117,6 +125,27 @@ bool messagebus_topic_read(messagebus_topic_t *topic, void *buf, size_t buf_len)
  * @parameter [out] buf_len Length of the buffer.
  */
 void messagebus_topic_wait(messagebus_topic_t *topic, void *buf, size_t buf_len);
+
+/** Initializes a watch group.
+ *
+ * Watch group are used to wait on a set of topics in parallel (similar to
+ * select(2) on UNIX). Each watchgroup has a lock and condition variable
+ * associated to it.
+ *
+ * @parameter [in] lock The lock to use for this group.
+ * @parameter [in] condvar The condition variable to use for this group.
+ */
+void messagebus_watchgroup_init(messagebus_watchgroup_t *group, void *lock,
+                                void *condvar);
+
+/** Adds a topic to a given group.
+ *
+ * @warning Removing a watchgroup is not supported for now.
+ */
+void messagebus_watchgroup_watch(messagebus_watchgroup_t *group,
+                                 messagebus_topic_t *topic);
+
+messagebus_topic_t *messagebus_watchgroup_wait(messagebus_watchgroup_t *group);
 
 /** @defgroup portable Portable functions, platform specific.
  * @{*/

--- a/messagebus.h
+++ b/messagebus.h
@@ -15,9 +15,9 @@ typedef struct topic_s {
     void *lock;
     void *condvar;
     char name[TOPIC_NAME_MAX_LENGTH + 1];
-    struct topic_s *next;
     bool published;
-    struct messagebus_watchgroup_s *groups;
+    struct messagebus_watcher_s *watchers;
+    struct topic_s *next;
 } messagebus_topic_t;
 
 typedef struct {
@@ -31,9 +31,13 @@ typedef struct {
 typedef struct messagebus_watchgroup_s {
     void *lock;
     void *condvar;
-    struct messagebus_watchgroup_s *next;
     messagebus_topic_t *published_topic;
 } messagebus_watchgroup_t;
+
+typedef struct messagebus_watcher_s {
+    messagebus_watchgroup_t *group;
+    struct messagebus_watcher_s *next;
+} messagebus_watcher_t;
 
 #define MESSAGEBUS_TOPIC_FOREACH(_bus, _topic_var_name) \
     for (int __control = -1; __control < 2; __control++) \
@@ -142,7 +146,8 @@ void messagebus_watchgroup_init(messagebus_watchgroup_t *group, void *lock,
  *
  * @warning Removing a watchgroup is not supported for now.
  */
-void messagebus_watchgroup_watch(messagebus_watchgroup_t *group,
+void messagebus_watchgroup_watch(messagebus_watcher_t *watcher,
+                                 messagebus_watchgroup_t *group,
                                  messagebus_topic_t *topic);
 
 messagebus_topic_t *messagebus_watchgroup_wait(messagebus_watchgroup_t *group);

--- a/package.yml
+++ b/package.yml
@@ -10,9 +10,14 @@ tests:
     - tests/msgbus.cpp
     - tests/signaling.cpp
     - tests/foreach.cpp
+    - tests/watchgroups.cpp
 
 target.demo:
     - examples/posix/demo.c
+    - examples/posix/port.c
+
+target.demo_watchgroups:
+    - examples/posix/demo_watchgroups.c
     - examples/posix/port.c
 
 target.arm:

--- a/tests/watchgroups.cpp
+++ b/tests/watchgroups.cpp
@@ -1,0 +1,126 @@
+#include <CppUTest/TestHarness.h>
+#include <CppUTestExt/MockSupport.h>
+#include "../messagebus.h"
+#include "mocks/synchronization.hpp"
+
+TEST_GROUP(Watchgroups)
+{
+    messagebus_watchgroup_t group;
+    messagebus_topic_t topic;
+    int lock, condvar;
+
+    void setup()
+    {
+        messagebus_topic_init(&topic, NULL, NULL, NULL, 0);
+        messagebus_watchgroup_init(&group, &lock, &condvar);
+    }
+
+    void teardown()
+    {
+        lock_mocks_enable(false);
+        condvar_mocks_enable(false);
+    }
+};
+
+TEST(Watchgroups, CanInitWatchGroup)
+{
+    POINTERS_EQUAL(&lock, group.lock);
+    POINTERS_EQUAL(&condvar, group.condvar);
+}
+
+TEST(Watchgroups, CanAddTopicToGroup)
+{
+    messagebus_watchgroup_watch(&group, &topic);
+    POINTERS_EQUAL(&group, topic.groups);
+}
+
+TEST(Watchgroups, CanAddTopicToDifferentGroups)
+{
+    messagebus_watchgroup_t second_group;
+    messagebus_watchgroup_init(&second_group, NULL, NULL);
+
+    messagebus_watchgroup_watch(&group, &topic);
+    messagebus_watchgroup_watch(&second_group, &topic);
+
+    POINTERS_EQUAL(&second_group, topic.groups);
+    POINTERS_EQUAL(&group, topic.groups->next);
+}
+
+TEST(Watchgroups, CanWaitOnGroup)
+{
+    group.published_topic = &topic;
+
+    lock_mocks_enable(true);
+    condvar_mocks_enable(true);
+
+    mock().strictOrder();
+    mock().expectOneCall("messagebus_lock_acquire").withPointerParameter("lock", group.lock);
+    mock().expectOneCall("messagebus_condvar_wait").withPointerParameter("var", group.condvar);
+    mock().expectOneCall("messagebus_lock_release").withPointerParameter("lock", group.lock);
+
+    auto res = messagebus_watchgroup_wait(&group);
+    POINTERS_EQUAL(&topic, res);
+}
+
+TEST(Watchgroups, GroupIsWokeUpOnPublish)
+{
+    messagebus_watchgroup_watch(&group, &topic);
+
+    mock().strictOrder();
+
+    /* Normal publish on bus */
+    mock().expectOneCall("messagebus_lock_acquire").withPointerParameter("lock", topic.lock);
+    mock().expectOneCall("messagebus_condvar_broadcast").withPointerParameter("var", topic.condvar);
+
+    mock().expectOneCall("messagebus_lock_acquire").withPointerParameter("lock", group.lock);
+    mock().expectOneCall("messagebus_condvar_broadcast").withPointerParameter("var", group.condvar);
+    mock().expectOneCall("messagebus_lock_release").withPointerParameter("lock", group.lock);
+
+
+    mock().expectOneCall("messagebus_lock_release").withPointerParameter("lock", topic.lock);
+
+    lock_mocks_enable(true);
+    condvar_mocks_enable(true);
+
+    messagebus_topic_publish(&topic, NULL, 0);
+}
+
+TEST(Watchgroups, GroupHasTopic)
+{
+    messagebus_watchgroup_watch(&group, &topic);
+    messagebus_topic_publish(&topic, NULL, 0);
+    POINTERS_EQUAL(&topic, group.published_topic);
+}
+
+TEST(Watchgroups, AllGroupsAreSignaled)
+{
+    messagebus_watchgroup_t group2;
+    int lock2, var2;
+
+    messagebus_watchgroup_init(&group, &lock2, &var2);
+    messagebus_watchgroup_watch(&group2, &topic);
+    messagebus_watchgroup_watch(&group, &topic);
+
+    /* Normal publish on bus */
+    mock().expectOneCall("messagebus_lock_acquire").withPointerParameter("lock", topic.lock);
+    mock().expectOneCall("messagebus_condvar_broadcast").withPointerParameter("var", topic.condvar);
+
+
+    /* First group */
+    mock().expectOneCall("messagebus_lock_acquire").withPointerParameter("lock", group.lock);
+    mock().expectOneCall("messagebus_condvar_broadcast").withPointerParameter("var", group.condvar);
+    mock().expectOneCall("messagebus_lock_release").withPointerParameter("lock", group.lock);
+
+    /* Second group */
+    mock().expectOneCall("messagebus_lock_acquire").withPointerParameter("lock", group2.lock);
+    mock().expectOneCall("messagebus_condvar_broadcast").withPointerParameter("var", group2.condvar);
+    mock().expectOneCall("messagebus_lock_release").withPointerParameter("lock", group2.lock);
+
+    mock().expectOneCall("messagebus_lock_release").withPointerParameter("lock", topic.lock);
+
+    lock_mocks_enable(true);
+    condvar_mocks_enable(true);
+
+    messagebus_topic_publish(&topic, NULL, 0);
+
+}

--- a/tests/watchgroups.cpp
+++ b/tests/watchgroups.cpp
@@ -8,6 +8,7 @@ TEST_GROUP(Watchgroups)
     messagebus_watchgroup_t group;
     messagebus_topic_t topic;
     int lock, condvar;
+    messagebus_watcher_t watcher;
 
     void setup()
     {
@@ -30,20 +31,21 @@ TEST(Watchgroups, CanInitWatchGroup)
 
 TEST(Watchgroups, CanAddTopicToGroup)
 {
-    messagebus_watchgroup_watch(&group, &topic);
-    POINTERS_EQUAL(&group, topic.groups);
+    messagebus_watchgroup_watch(&watcher, &group, &topic);
+    POINTERS_EQUAL(&group, topic.watchers->group);
 }
 
 TEST(Watchgroups, CanAddTopicToDifferentGroups)
 {
+    messagebus_watcher_t w2;
     messagebus_watchgroup_t second_group;
     messagebus_watchgroup_init(&second_group, NULL, NULL);
 
-    messagebus_watchgroup_watch(&group, &topic);
-    messagebus_watchgroup_watch(&second_group, &topic);
+    messagebus_watchgroup_watch(&watcher, &group, &topic);
+    messagebus_watchgroup_watch(&w2, &second_group, &topic);
 
-    POINTERS_EQUAL(&second_group, topic.groups);
-    POINTERS_EQUAL(&group, topic.groups->next);
+    POINTERS_EQUAL(&second_group, topic.watchers->group);
+    POINTERS_EQUAL(&group, topic.watchers->next->group);
 }
 
 TEST(Watchgroups, CanWaitOnGroup)
@@ -64,7 +66,7 @@ TEST(Watchgroups, CanWaitOnGroup)
 
 TEST(Watchgroups, GroupIsWokeUpOnPublish)
 {
-    messagebus_watchgroup_watch(&group, &topic);
+    messagebus_watchgroup_watch(&watcher, &group, &topic);
 
     mock().strictOrder();
 
@@ -87,7 +89,7 @@ TEST(Watchgroups, GroupIsWokeUpOnPublish)
 
 TEST(Watchgroups, GroupHasTopic)
 {
-    messagebus_watchgroup_watch(&group, &topic);
+    messagebus_watchgroup_watch(&watcher, &group, &topic);
     messagebus_topic_publish(&topic, NULL, 0);
     POINTERS_EQUAL(&topic, group.published_topic);
 }
@@ -96,10 +98,12 @@ TEST(Watchgroups, AllGroupsAreSignaled)
 {
     messagebus_watchgroup_t group2;
     int lock2, var2;
+    messagebus_watcher_t w2;
+
+    messagebus_watchgroup_watch(&watcher, &group, &topic);
 
     messagebus_watchgroup_init(&group, &lock2, &var2);
-    messagebus_watchgroup_watch(&group2, &topic);
-    messagebus_watchgroup_watch(&group, &topic);
+    messagebus_watchgroup_watch(&w2, &group2, &topic);
 
     /* Normal publish on bus */
     mock().expectOneCall("messagebus_lock_acquire").withPointerParameter("lock", topic.lock);
@@ -123,4 +127,51 @@ TEST(Watchgroups, AllGroupsAreSignaled)
 
     messagebus_topic_publish(&topic, NULL, 0);
 
+}
+
+/* This test checks that we can have several group containing the same topics. */
+TEST(Watchgroups, GroupCanBeLinkedInMultipleTopics)
+{
+    messagebus_topic_t topic2;
+    messagebus_topic_init(&topic2, NULL, NULL, NULL, 0);
+
+    messagebus_watchgroup_t group2, group3;
+    int lock2, var2;
+
+    messagebus_watchgroup_init(&group2, &lock2, &var2);
+    messagebus_watchgroup_init(&group3, NULL, NULL);
+
+
+    /* Adds the first topic to two groups. */
+    messagebus_watcher_t watcher2;
+    messagebus_watchgroup_watch(&watcher, &group, &topic);
+    messagebus_watchgroup_watch(&watcher2, &group2, &topic);
+
+    /* Adds the second topic to two groups as well. */
+    messagebus_watcher_t watcher3, watcher1_2;
+    messagebus_watchgroup_watch(&watcher3, &group3, &topic2);
+    messagebus_watchgroup_watch(&watcher1_2, &group, &topic2);
+
+    /* Normal publish on first topic */
+    mock().expectOneCall("messagebus_lock_acquire").withPointerParameter("lock", topic.lock);
+    mock().expectOneCall("messagebus_condvar_broadcast").withPointerParameter("var", topic.condvar);
+
+
+    /* Published topic belongs to groups 1 & 2, lets start with group1. */
+    mock().expectOneCall("messagebus_lock_acquire").withPointerParameter("lock", group.lock);
+    mock().expectOneCall("messagebus_condvar_broadcast").withPointerParameter("var", group.condvar);
+    mock().expectOneCall("messagebus_lock_release").withPointerParameter("lock", group.lock);
+
+    /* Then group 2. */
+    mock().expectOneCall("messagebus_lock_acquire").withPointerParameter("lock", group2.lock);
+    mock().expectOneCall("messagebus_condvar_broadcast").withPointerParameter("var", group2.condvar);
+    mock().expectOneCall("messagebus_lock_release").withPointerParameter("lock", group2.lock);
+
+    /* Also a part of the normal publish cycle */
+    mock().expectOneCall("messagebus_lock_release").withPointerParameter("lock", topic.lock);
+
+    /* Finally, do the actuall publish. */
+    lock_mocks_enable(true);
+    condvar_mocks_enable(true);
+    messagebus_topic_publish(&topic, NULL, 0);
 }


### PR DESCRIPTION
Bus watchgroups are my solution to the "select" problem: how can we wait
on many topics in a single thread in a portable way? This is required,
e.g. to forward topics over UDP, log them, or whatever.

The chosen approach is to group topics under a single condition variable
that will be signaled every time a topic in the group is published to.

This commit also adds a demo application showcasing this feature by
implementing an observer monitoring two topics.

I would like some careful review, especially since this touches some critical locking code.