### PR TITLE
Add some metadata & callback on new topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 * Each topic can have a metadata block.
     It can be used to contain function pointers to serialization / deserialization methods for example.
     Metadata do not offer the same atomicity guarantees as the topic data themselves.
+* Possibility to register callbacks that are triggered on topic creation.
 
 ## Features that won't be supported
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
 * Can poll to see if there was an update to the message.
 * Topics are atomic.
 * Different serialization methods are possible.
+* Each topic can have a metadata block.
+    It can be used to contain function pointers to serialization / deserialization methods for example.
+    Metadata do not offer the same atomicity guarantees as the topic data themselves.
 
 ## Features that won't be supported
 

--- a/messagebus.h
+++ b/messagebus.h
@@ -25,6 +25,7 @@ typedef struct {
     struct {
         messagebus_topic_t *head;
     } topics;
+    struct messagebus_new_topic_cb_s *new_topic_callback_list;
     void *lock;
     void *condvar;
 } messagebus_t;
@@ -39,6 +40,12 @@ typedef struct messagebus_watcher_s {
     messagebus_watchgroup_t *group;
     struct messagebus_watcher_s *next;
 } messagebus_watcher_t;
+
+typedef struct messagebus_new_topic_cb_s {
+    void (*callback)(messagebus_t *, messagebus_topic_t *, void *);
+    void *callback_arg;
+    struct messagebus_new_topic_cb_s *next;
+} messagebus_new_topic_cb_t;
 
 #define MESSAGEBUS_TOPIC_FOREACH(_bus, _topic_var_name) \
     for (int __control = -1; __control < 2; __control++) \
@@ -152,6 +159,15 @@ void messagebus_watchgroup_watch(messagebus_watcher_t *watcher,
                                  messagebus_topic_t *topic);
 
 messagebus_topic_t *messagebus_watchgroup_wait(messagebus_watchgroup_t *group);
+
+/** Registers a callback that will trigger when a new topic is advertised on
+ * the bus. */
+void messagebus_new_topic_callback_register(messagebus_t *bus,
+                                            messagebus_new_topic_cb_t *cb,
+                                            void (*cb_fun)(messagebus_t *,
+                                                           messagebus_topic_t *,
+                                                           void *),
+                                            void *arg);
 
 /** @defgroup portable Portable functions, platform specific.
  * @{*/

--- a/messagebus.h
+++ b/messagebus.h
@@ -18,6 +18,7 @@ typedef struct topic_s {
     bool published;
     struct messagebus_watcher_s *watchers;
     struct topic_s *next;
+    void *metadata;
 } messagebus_topic_t;
 
 typedef struct {

--- a/package.yml
+++ b/package.yml
@@ -11,6 +11,7 @@ tests:
     - tests/signaling.cpp
     - tests/foreach.cpp
     - tests/watchgroups.cpp
+    - tests/new_topic_callbacks.cpp
 
 target.demo:
     - examples/posix/demo.c

--- a/tests/atomicity.cpp
+++ b/tests/atomicity.cpp
@@ -132,3 +132,19 @@ TEST(MessageBusAtomicityTestGroup, FindBlocking)
 
     messagebus_find_topic_blocking(&bus, "topic");
 }
+
+TEST(MessageBusAtomicityTestGroup, RegisterNewTopicCallback)
+{
+    messagebus_advertise_topic(&bus, &topic, "topic");
+    messagebus_new_topic_cb_t cb;
+
+    lock_mocks_enable(true);
+
+    mock().expectOneCall("messagebus_lock_acquire")
+          .withPointerParameter("lock", bus.lock);
+
+    mock().expectOneCall("messagebus_lock_release")
+          .withPointerParameter("lock", bus.lock);
+
+    messagebus_new_topic_callback_register(&bus, &cb, nullptr, nullptr);
+}

--- a/tests/msgbus.cpp
+++ b/tests/msgbus.cpp
@@ -29,6 +29,11 @@ TEST(MessageBusTestGroup, CanCreateTopicWithBuffer)
     CHECK_EQUAL(topic.buffer_len, sizeof(buffer));
 }
 
+TEST(MessageBusTestGroup, HasMetadataField)
+{
+    POINTERS_EQUAL(NULL, topic.metadata);
+}
+
 TEST(MessageBusTestGroup, CanCreateBus)
 {
     POINTERS_EQUAL(NULL, bus.topics.head);
@@ -143,4 +148,3 @@ TEST(MessageBusTestGroup, WaitForUpdate)
 
     CHECK_EQUAL(tx, rx);
 }
-

--- a/tests/new_topic_callbacks.cpp
+++ b/tests/new_topic_callbacks.cpp
@@ -1,0 +1,54 @@
+#include <CppUTest/TestHarness.h>
+#include <CppUTestExt/MockSupport.h>
+#include "../messagebus.h"
+
+TEST_GROUP(NewTopicCallback)
+{
+    messagebus_t bus;
+    messagebus_topic_t topic;
+    messagebus_new_topic_cb_t cb;
+
+    void setup()
+    {
+        messagebus_init(&bus, NULL, NULL);
+        messagebus_topic_init(&topic, NULL, NULL, NULL, 0);
+    }
+};
+
+void my_cb(messagebus_t *bus, messagebus_topic_t *topic, void *arg)
+{
+    mock().actualCall("my_cb")
+        .withPointerParameter("bus", bus)
+        .withPointerParameter("topic", topic)
+        .withPointerParameter("arg", arg);
+}
+
+TEST(NewTopicCallback, CanRegisterCallback)
+{
+    messagebus_new_topic_callback_register(&bus, &cb, my_cb, (void *)0x1234);
+
+    POINTERS_EQUAL(my_cb, cb.callback);
+    POINTERS_EQUAL((void *)0x1234, cb.callback_arg);
+    POINTERS_EQUAL(&cb, bus.new_topic_callback_list);
+    POINTERS_EQUAL(NULL, cb.next);
+}
+
+
+TEST(NewTopicCallback, CallbackFiresSeveralTime)
+{
+    messagebus_new_topic_cb_t cb2;
+    messagebus_new_topic_callback_register(&bus, &cb, my_cb, (void *)0x1234);
+    messagebus_new_topic_callback_register(&bus, &cb2, my_cb, (void *)0x4321);
+
+    POINTERS_EQUAL(&cb, cb2.next);
+
+    mock().expectOneCall("my_cb")
+        .withPointerParameter("bus", &bus)
+        .withPointerParameter("topic", &topic)
+        .withPointerParameter("arg", (void *)0x1234);
+    mock().expectOneCall("my_cb")
+        .withPointerParameter("bus", &bus)
+        .withPointerParameter("topic", &topic)
+        .withPointerParameter("arg", (void *)0x4321);
+    messagebus_advertise_topic(&bus, &topic, "/foo");
+}


### PR DESCRIPTION
This PR adds metadata fields and the possibility to trigger callbacks on topic creation.

I plan to use this to add automatic sending of bus messages over a UDP link or storage on a micro SD card. The callback will be used to instantiate relevant parameters while the 