### PR TITLE
Basic C++ bindings

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -3,6 +3,7 @@ cc_library(
     srcs = [
         "messagebus.c",
         "messagebus.h",
+        "messagebus_cpp.hpp",
     ],
     hdrs = ["messagebus.h"],
     include_prefix = "msgbus",

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,50 @@
+cc_library(
+    name = "msgbus",
+    srcs = [
+        "messagebus.c",
+        "messagebus.h",
+    ],
+    hdrs = ["messagebus.h"],
+    include_prefix = "msgbus",
+    visibility = ["//visibility:public"],
+    # TODO: Add ChibiOS port
+    deps = select({
+        "//conditions:default": [":msgbus-pthread"],
+    }),
+)
+
+cc_test(
+    name = "msgbus-test",
+    size = "small",
+    srcs = glob([
+        "tests/*.cpp",
+        "tests/mocks/*.cpp",
+        "tests/mocks/*.hpp",
+    ]),
+    deps = [
+        ":msgbus",
+        "@ch_cvra_test_runner//:main",
+    ],
+)
+
+cc_library(
+    name = "msgbus-pthread",
+    srcs = [
+        "examples/posix/port.c",
+        "messagebus.h",
+    ],
+    hdrs = ["examples/posix/port.h"],
+    linkopts = ["-pthread"],
+)
+
+cc_binary(
+    name = "msgbus-demo",
+    srcs = ["examples/posix/demo.c"],
+    deps = [":msgbus"],
+)
+
+cc_binary(
+    name = "msgbus-demo-watchgroups",
+    srcs = ["examples/posix/demo_watchgroups.c"],
+    deps = [":msgbus"],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "ch_cvra_msgbus")

--- a/messagebus.c
+++ b/messagebus.c
@@ -83,7 +83,7 @@ messagebus_topic_t *messagebus_find_topic_blocking(messagebus_t *bus, const char
     return res;
 }
 
-bool messagebus_topic_publish(messagebus_topic_t *topic, void *buf, size_t buf_len)
+bool messagebus_topic_publish(messagebus_topic_t *topic, const void *buf, size_t buf_len)
 {
     if (topic->buffer_len < buf_len) {
         return false;

--- a/messagebus.h
+++ b/messagebus.h
@@ -188,5 +188,7 @@ extern void messagebus_condvar_wait(void *var);
 
 #ifdef __cplusplus
 }
+#include "messagebus_cpp.hpp"
 #endif
+
 #endif

--- a/messagebus.h
+++ b/messagebus.h
@@ -117,7 +117,7 @@ messagebus_topic_t *messagebus_find_topic_blocking(messagebus_t *bus, const char
  * false is returned.
  * @returns True if successful, otherwise.
  */
-bool messagebus_topic_publish(messagebus_topic_t *topic, void *buf, size_t buf_len);
+bool messagebus_topic_publish(messagebus_topic_t *topic, const void *buf, size_t buf_len);
 
 /** Reads the content of a single topic.
  *

--- a/messagebus_cpp.hpp
+++ b/messagebus_cpp.hpp
@@ -71,6 +71,6 @@ TopicWrapper<T>::operator bool()
     return topic != nullptr;
 }
 
-} // nmaespace messagebus
+} // namespace messagebus
 
 #endif

--- a/messagebus_cpp.hpp
+++ b/messagebus_cpp.hpp
@@ -1,0 +1,76 @@
+#ifndef MESSAGEBUS_CPP_HPP
+#define MESSAGEBUS_CPP_HPP
+
+namespace messagebus
+{
+template <typename T>
+class TopicWrapper
+{
+public:
+    TopicWrapper(messagebus_topic_t *t);
+
+    /// Wrapper around messagebus_topic_publish
+    void publish(const T &msg);
+
+    /// Wrapper around messagebus_topic_read
+    bool read(T &msg);
+
+    /// Wrapper around messagebus_topic_wait
+    T wait();
+
+    /// Returns true if this wraps a valid topic (i.e. not nullptr)
+    operator bool();
+
+private:
+    messagebus_topic_t *topic;
+};
+
+template <typename T>
+TopicWrapper<T> find_topic(messagebus_t &bus, const char *topic_name)
+{
+    auto topic = messagebus_find_topic(&bus, topic_name);
+    return TopicWrapper<T>(topic);
+}
+
+template <typename T>
+TopicWrapper<T> find_topic_blocking(messagebus_t &bus, const char *topic_name)
+{
+    auto topic = messagebus_find_topic_blocking(&bus, topic_name);
+    return TopicWrapper<T>(topic);
+}
+
+template <typename T>
+TopicWrapper<T>::TopicWrapper(messagebus_topic_t *t)
+    : topic(t)
+{
+}
+
+template <typename T>
+void TopicWrapper<T>::publish(const T &msg)
+{
+    messagebus_topic_publish(topic, &msg, sizeof(T));
+}
+
+template <typename T>
+bool TopicWrapper<T>::read(T &msg)
+{
+    return messagebus_topic_read(topic, &msg, sizeof(T));
+}
+
+template <typename T>
+T TopicWrapper<T>::wait()
+{
+    T res;
+    messagebus_topic_wait(topic, &res, sizeof(T));
+    return res;
+}
+
+template <typename T>
+TopicWrapper<T>::operator bool()
+{
+    return topic != nullptr;
+}
+
+} // nmaespace messagebus
+
+#endif

--- a/package.yml
+++ b/package.yml
@@ -12,6 +12,7 @@ tests:
     - tests/foreach.cpp
     - tests/watchgroups.cpp
     - tests/new_topic_callbacks.cpp
+    - tests/test_cpp_interface.cpp
 
 target.demo:
     - examples/posix/demo.c

--- a/tests/test_cpp_interface.cpp
+++ b/tests/test_cpp_interface.cpp
@@ -24,7 +24,8 @@ TEST(MessagebusCppInterface, CanPublish)
     topic->publish(42);
 
     int read_msg;
-    auto res = messagebus_topic_read(&raw_topic, &read_msg, sizeof(read_msg));
+    bool res = messagebus_topic_read(&raw_topic, &read_msg, sizeof(read_msg));
+
     CHECK_TRUE(res);
     CHECK_EQUAL(42, read_msg);
 }
@@ -35,7 +36,7 @@ TEST(MessagebusCppInterface, CanRead)
     messagebus_topic_publish(&raw_topic, &msg, sizeof(msg));
 
     int read_msg;
-    auto res = topic->read(read_msg);
+    bool res = topic->read(read_msg);
 
     CHECK_TRUE(res);
     CHECK_EQUAL(msg, read_msg);
@@ -58,11 +59,11 @@ TEST(MessagebusCppInterface, CanCheckIfTopicExists)
 TEST(MessagebusCppInterface, CanFindTopic)
 {
     auto topic = messagebus::find_topic<int>(bus, "/foo");
-    topic.publish(42);
+    CHECK_TRUE(topic);
 }
 
 TEST(MessagebusCppInterface, CanFindTopicBlocking)
 {
     auto topic = messagebus::find_topic_blocking<int>(bus, "/foo");
-    topic.publish(42);
+    CHECK_TRUE(topic);
 }

--- a/tests/test_cpp_interface.cpp
+++ b/tests/test_cpp_interface.cpp
@@ -1,0 +1,68 @@
+#include <CppUTest/TestHarness.h>
+#include <CppUTestExt/MockSupport.h>
+#include <memory>
+#include "../messagebus.h"
+
+
+TEST_GROUP(MessagebusCppInterface)
+{
+    messagebus_topic_t raw_topic;
+    int topic_content;
+    messagebus_t bus;
+    std::unique_ptr<messagebus::TopicWrapper<int> > topic;
+    void setup(void)
+    {
+        messagebus_topic_init(&raw_topic, nullptr, nullptr, &topic_content, sizeof(topic_content));
+        messagebus_init(&bus, nullptr, nullptr);
+        messagebus_advertise_topic(&bus, &raw_topic, "/foo");
+        topic = std::make_unique<messagebus::TopicWrapper<int> >(&raw_topic);
+    }
+};
+
+TEST(MessagebusCppInterface, CanPublish)
+{
+    topic->publish(42);
+
+    int read_msg;
+    auto res = messagebus_topic_read(&raw_topic, &read_msg, sizeof(read_msg));
+    CHECK_TRUE(res);
+    CHECK_EQUAL(42, read_msg);
+}
+
+TEST(MessagebusCppInterface, CanRead)
+{
+    int msg = 42;
+    messagebus_topic_publish(&raw_topic, &msg, sizeof(msg));
+
+    int read_msg;
+    auto res = topic->read(read_msg);
+
+    CHECK_TRUE(res);
+    CHECK_EQUAL(msg, read_msg);
+}
+
+TEST(MessagebusCppInterface, CanWait)
+{
+    int msg = 42;
+    messagebus_topic_publish(&raw_topic, &msg, sizeof(msg));
+
+    CHECK_EQUAL(42, topic->wait());
+}
+
+TEST(MessagebusCppInterface, CanCheckIfTopicExists)
+{
+    CHECK_TRUE(messagebus::TopicWrapper<int>(&raw_topic));
+    CHECK_FALSE(messagebus::TopicWrapper<int>(nullptr));
+}
+
+TEST(MessagebusCppInterface, CanFindTopic)
+{
+    auto topic = messagebus::find_topic<int>(bus, "/foo");
+    topic.publish(42);
+}
+
+TEST(MessagebusCppInterface, CanFindTopicBlocking)
+{
+    auto topic = messagebus::find_topic_blocking<int>(bus, "/foo");
+    topic.publish(42);
+}


### PR DESCRIPTION
This PR implements basic C++ wrappers for messagebus topics.
It does not intent on replacing the existing C code but simply wrapping it into a C++ class to be (more) type safe.
The API also becomes *much* less verbose:

```cpp
// Old style C API
Point msg = {10, 10};
messagebus_topic_t *topic = messagebus_find_topic_blocking(&bus, "/foobar");
messagebus_topic_publish(topic, &msg, sizeof(msg));

// New style C++ API
auto topic = messagebus::find_topic_blocking<Point>(bus, "/foobar");
topic.publish({10, 10});
```

I do not know if it is ready for CVRA production though. I plan to use it for Hydrocontest, but haven't tested it "live" already.

Since this does not change the underlying C implementation, it can allow c++ module and c modules to communicate. This approach could work for Rust if we someday decide to use it.
